### PR TITLE
feat(music-generation): add model feedback

### DIFF
--- a/src/Applications/CanvasCapture/CanvasCapture/Classes/ModelFeedbackFileWriter.cs
+++ b/src/Applications/CanvasCapture/CanvasCapture/Classes/ModelFeedbackFileWriter.cs
@@ -1,0 +1,18 @@
+﻿namespace CanvasCapture.Classes
+{
+    public class ModelFeedbackFileWriter(string directoryPath)
+    {
+        private const string FileName = "ModelFeedback.txt";
+        private readonly string FilePath = Path.Join(directoryPath, FileName);
+
+        public async Task Write(string content)
+        {
+            if (!File.Exists(FilePath))
+            {
+                return;
+            }
+
+            await File.AppendAllTextAsync(FilePath, content + Environment.NewLine);
+        }
+    }
+}

--- a/src/Applications/CanvasCapture/CanvasCaptureUI/CanvasCaptureMain.cs
+++ b/src/Applications/CanvasCapture/CanvasCaptureUI/CanvasCaptureMain.cs
@@ -9,6 +9,7 @@ namespace CanvasCapture
     {
         private const string autoAppShutDownKey = "Shut down on performance end";
         private const string runAsSimKey = "Run as a simulation";
+        private const string logModelDecisionsKey = "View model decision feedback";
 
         private ICanvasCaptureProcess canvasCaptureProcess;
         private readonly Dictionary<string, bool> options;
@@ -16,6 +17,7 @@ namespace CanvasCapture
         {
             { autoAppShutDownKey, true },
             { runAsSimKey, false },
+            { logModelDecisionsKey, true },
         };
         private readonly List<string> instruments = [
             "Piano",
@@ -30,7 +32,7 @@ namespace CanvasCapture
             options = defaultOptions;
             ConfigureSettings();
             ConfigureLogger();
-            canvasCaptureProcess = new Performance(pictureBoxImages);
+            canvasCaptureProcess = new Performance(pictureBoxImages, IsDevOptionSelected(logModelDecisionsKey));
         }
 
         #region Button Controls

--- a/src/Applications/CanvasCapture/CanvasCaptureUI/Classes/Performance.cs
+++ b/src/Applications/CanvasCapture/CanvasCaptureUI/Classes/Performance.cs
@@ -2,19 +2,21 @@
 using CanvasCapture.Interfaces;
 using Core.DataStructures.Art;
 using Core.DataStructures.Music;
+using Core.DataStructures.Result;
 using Core.Enums.AI;
 using Core.Interfaces;
 using MusicGeneration;
 using Serilog;
 namespace CanvasCaptureUI.Classes
 {
-    internal class Performance(PictureBox displayBox) : ICanvasCaptureProcess
+    internal class Performance(PictureBox displayBox, bool logModelDecisions) : ICanvasCaptureProcess
     {
         private readonly string imageDirectory = AppSettingsManager.GetImageDirectory("Performance");
         private readonly ICoreMusicProducer coreMusicProducer = CoreMusicGeneratorFactory.ConstructMusicGenerator(Model.Markov);
         private readonly ImageCropper cropper = new(displayBox);
         private readonly MusicPlayerClient playerClient = new();
         private readonly List<ObjectAttributes> objectAttributesCache = [];
+        private readonly ModelFeedbackFileWriter? modelFeedbackWriter = logModelDecisions ? new ModelFeedbackFileWriter(AppSettingsManager.GetImageDirectory("Performance")) : null;
         
         private CanvasAttributes? canvasAttributesCache;
         private FileSystemWatcher? fileSystemWatcher;
@@ -125,9 +127,11 @@ namespace CanvasCaptureUI.Classes
 
                 Log.Debug("Canvas Attributes: {CanvasData}", canvasAttributesCache);
 
-                MusicData musicData = coreMusicProducer.Add(objectAttributes, canvasAttributesCache);
+                CoreResult result = coreMusicProducer.Add(objectAttributes, canvasAttributesCache);
 
-                musicData.Instrument = Instruments[0];
+                result.MusicData.Instrument = Instruments[0];
+
+                MusicData musicData = result.MusicData;
 
                 List<Note> adjustedNotes = AdjustPitches(ref musicData);
 
@@ -144,6 +148,8 @@ namespace CanvasCaptureUI.Classes
                 displayBox.Image = postProcessingImage;
 
                 Log.Debug($"Music Data: {musicData}");
+
+                modelFeedbackWriter?.Write(result.ModelDecisionLogic);
 
                 await playerClient.SendPayload(musicData);
 

--- a/src/Applications/CanvasCapture/CanvasCaptureUI/Classes/Performance.cs
+++ b/src/Applications/CanvasCapture/CanvasCaptureUI/Classes/Performance.cs
@@ -64,6 +64,7 @@ namespace CanvasCaptureUI.Classes
             objectAttributesCache.Clear();
 
             coreMusicProducer.Clear();
+            modelFeedbackWriter?.Write("END" + Environment.NewLine);
             await playerClient.Stop();
             fileSystemWatcher?.Dispose();
             displayBox?.Image?.Dispose();

--- a/src/Applications/CanvasCapture/CanvasCaptureUI/Simulation/ImageProcessingSimulator.cs
+++ b/src/Applications/CanvasCapture/CanvasCaptureUI/Simulation/ImageProcessingSimulator.cs
@@ -7,6 +7,7 @@ using MusicGeneration;
 using Core.DataStructures.Music;
 using CanvasCapture.Interfaces;
 using Serilog;
+using Core.DataStructures.Result;
 
 namespace CanvasCaptureUI.Simulation
 {
@@ -110,9 +111,10 @@ namespace CanvasCaptureUI.Simulation
 
                     Log.Information($"{CanvasAttributesCache}{Environment.NewLine}{Environment.NewLine}");
 
-                    MusicData musicData = coreMusicProducer.Add(data, CanvasAttributesCache);
+                    CoreResult result = coreMusicProducer.Add(data, CanvasAttributesCache);
 
-                    Log.Information($"{musicData}{Environment.NewLine}{Environment.NewLine}");
+                    Log.Information($"{result.ModelDecisionLogic}");
+                    Log.Information($"{result.MusicData}{Environment.NewLine}{Environment.NewLine}");
 
                     ImageCache = image;
                 }

--- a/src/Applications/SketchpadServer/SketchpadServer/Classes/CoreAdapter.cs
+++ b/src/Applications/SketchpadServer/SketchpadServer/Classes/CoreAdapter.cs
@@ -32,7 +32,7 @@ namespace SketchpadServer.Classes
                 _canvasAttributes.AreaCovered += objectAttributes.Area;
             }
 
-            return _coreMusicProducer.Add(objectAttributes, _canvasAttributes);
+            return _coreMusicProducer.Add(objectAttributes, _canvasAttributes).MusicData;
         }
 
         public void DeleteShape(string shapeID) 

--- a/src/Applications/SketchpadServer/SketchpadServer/Classes/WebsocketServer.cs
+++ b/src/Applications/SketchpadServer/SketchpadServer/Classes/WebsocketServer.cs
@@ -80,7 +80,7 @@ namespace SketchpadServer.Classes
                     else
                     {
                         var receivedMessage = Encoding.UTF8.GetString(buffer, 0, result.Count);
-                        _logger.LogDebug("Message Received: {0}", receivedMessage);
+                        _logger.LogDebug("Message Received: {message}", receivedMessage);
 
                         UpdateShapes? payload = JsonConvert.DeserializeObject<UpdateShapes>(receivedMessage);
 

--- a/src/Applications/SketchpadServer/Tests/SketchpadServerTests/Classes/CoreAdapterTests.cs
+++ b/src/Applications/SketchpadServer/Tests/SketchpadServerTests/Classes/CoreAdapterTests.cs
@@ -12,6 +12,13 @@ namespace SketchpadServerTests.Classes
     {
         private readonly Mock<ICoreMusicProducer> _mockCoreMusicProducer;
         private readonly CoreAdapter _coreAdapter;
+        
+        private readonly MusicData _mockMusicData = new()
+        {
+            Instrument = "Piano",
+            BPM = 120,
+            Notes = []
+        };
 
         public CoreAdapterTests()
         {
@@ -27,12 +34,7 @@ namespace SketchpadServerTests.Classes
             var objectAttributes = CoreDataMapper.MapToCoreData(ref updateShapes);
             _mockCoreMusicProducer
                 .Setup(x => x.Add(It.IsAny<ObjectAttributes>(), It.IsAny<CanvasAttributes>()))
-                .Returns(new MusicData() 
-                { 
-                    Instrument = "Piano",
-                    BPM = 120,
-                    Notes = []
-                });
+                .Returns(new Core.DataStructures.Result.CoreResult() { MusicData = _mockMusicData});
 
             // Act
             var result = _coreAdapter.GenerateMusic(updateShapes);

--- a/src/Shared/Core/Core/DataStructures/Result/CoreResult.cs
+++ b/src/Shared/Core/Core/DataStructures/Result/CoreResult.cs
@@ -1,0 +1,11 @@
+﻿using Core.DataStructures.Music;
+
+namespace Core.DataStructures.Result
+{
+    public class CoreResult
+    {
+        public string ModelDecisionLogic { get; set; } = string.Empty;
+
+        public required MusicData MusicData { get; set; }
+    }
+}

--- a/src/Shared/Core/Core/Interfaces/ICoreMusicProducer.cs
+++ b/src/Shared/Core/Core/Interfaces/ICoreMusicProducer.cs
@@ -1,13 +1,12 @@
 ﻿using Core.DataStructures.Art;
-using Core.DataStructures.Music;
+using Core.DataStructures.Result;
 
 namespace Core.Interfaces
 {
     public interface ICoreMusicProducer
     {
-        public MusicData Add(ObjectAttributes imageAttributes, CanvasAttributes canvasAttributes);
+        public CoreResult Add(ObjectAttributes imageAttributes, CanvasAttributes canvasAttributes);
         public void Remove(ObjectAttributes imageAttributes, CanvasAttributes canvasAttributes);
-
         public void Clear();
     }
 }

--- a/src/Shared/Infrastructure/MusicGeneration/MusicGeneration/Models/Markov/Helpers/AttributeMapper.cs
+++ b/src/Shared/Infrastructure/MusicGeneration/MusicGeneration/Models/Markov/Helpers/AttributeMapper.cs
@@ -10,11 +10,17 @@ namespace MusicGeneration.Models.Markov.Helpers
         private const double maxDistanceFromCentre = 0.5;
         private const int minAcceptablePitch = 20;
 
-        public static int GetPitch(ref ObjectAttributes imageAttributes)
+        public static int GetPitch(ref ObjectAttributes imageAttributes, ref string feedback)
         {
-            double[] attributesOfInterest = [1 - imageAttributes.Area, imageAttributes.Temperature, imageAttributes.Complexity];
+            double area = imageAttributes.Area;
+            double temp = imageAttributes.Temperature;
+            double complex = imageAttributes.Complexity;
+
+            double[] attributesOfInterest = [1 - area, temp, complex];
 
             int pitch = (int)(attributesOfInterest.Average() * pitchMultiplier);
+
+            feedback += $"A combination of {nameof(imageAttributes.Area)}, {nameof(imageAttributes.Temperature)}, and {nameof(imageAttributes.Complexity)} has given a pitch value {pitch}. ";
 
             if (pitch < minAcceptablePitch)
                 pitch += 20;
@@ -29,20 +35,28 @@ namespace MusicGeneration.Models.Markov.Helpers
             return (int)((127 - 80) * (maxDistanceFromCentre - value) / maxDistanceFromCentre) + 80;
         }
 
-        public static double GetNoteLength(ref ObjectAttributes imageAttributes)
+        public static double GetNoteLength(ref ObjectAttributes imageAttributes, ref string feedback)
         {
             double[] thresholds = [.25, .5, .75, 1.0];
             double[] outputs = [.25, .5, 1.0, 1.5];
 
-            return MapValueToOutput(thresholds, outputs, 1 - imageAttributes.Complexity);
+            double result = MapValueToOutput(thresholds, outputs, 1 - imageAttributes.Complexity);
+
+            feedback += $"The object {nameof(imageAttributes.Complexity)} has a score of {imageAttributes.Complexity}, this maps to {result} note length. ";
+
+            return result;
         }
 
-        public static int GetNumberOfNotes(ref ObjectAttributes imageAttributes)
+        public static int GetNumberOfNotes(ref ObjectAttributes imageAttributes, ref string feedback)
         {
             double[] thresholds = [.2, .4, .6, .8, 1.0];
             int[] outputs = [4, 6, 8, 10, 12];
 
-            return MapValueToOutput(thresholds, outputs, imageAttributes.Complexity);
+            int result = MapValueToOutput(thresholds, outputs, imageAttributes.Complexity);
+
+            feedback += $"I am selecting {result} number of notes for new motif. ";
+
+            return result;
         }
 
         public static int GetBPM(ref CanvasAttributes canvasAttributes, int numberOfObjects)

--- a/src/Shared/Infrastructure/MusicGeneration/TestApplication/MusicGenerationTestApplication/Pages/ModelInvestigation.cs
+++ b/src/Shared/Infrastructure/MusicGeneration/TestApplication/MusicGenerationTestApplication/Pages/ModelInvestigation.cs
@@ -1,6 +1,7 @@
 ﻿using ConsoleTools.Helpers;
 using Core.DataStructures.Art;
 using Core.DataStructures.Music;
+using Core.DataStructures.Result;
 using Core.Interfaces;
 using MusicGenerationTestApplication.Utilities;
 using System.Text.Json;
@@ -59,12 +60,12 @@ namespace MusicGenerationTestApplication.Pages
 
             ObjectAttributes objectAttributes = MockDataProvider.GetRandomObjectAttributes();
 
-            MusicData music = coreMusicProducer.Add(objectAttributes, 
+            CoreResult result = coreMusicProducer.Add(objectAttributes, 
                                                     MockDataProvider.GetRandomCanvasAttributes());
 
             attributesCache.Add(objectAttributes.Id, objectAttributes);
 
-            string json = JsonSerializer.Serialize<MusicData>(music, jsonSerializerOptions);
+            string json = JsonSerializer.Serialize<CoreResult>(result, jsonSerializerOptions);
 
             Console.WriteLine(json);
 

--- a/src/Shared/Infrastructure/MusicGeneration/TestApplication/MusicGenerationTestApplication/Pages/ModelInvestigation.cs
+++ b/src/Shared/Infrastructure/MusicGeneration/TestApplication/MusicGenerationTestApplication/Pages/ModelInvestigation.cs
@@ -1,6 +1,5 @@
 ﻿using ConsoleTools.Helpers;
 using Core.DataStructures.Art;
-using Core.DataStructures.Music;
 using Core.DataStructures.Result;
 using Core.Interfaces;
 using MusicGenerationTestApplication.Utilities;


### PR DESCRIPTION
## Overview
This PR aims to add a mechanism to allow feedback to provided on the decisions the music generation system makes.  The aim of this is to provide further context to the user.

## Notes
* The current implementation of canvas capture is to write this feedback to an external text file which is monitored by another application
* Sketchpad Server currently ignores the feedback.  We can extend this when needed.